### PR TITLE
Null-check the `royalty` and `MostSeniorTitle` fields

### DIFF
--- a/1.6/Source/VanillaSocialInteractionsExpanded/Thoughts/ThoughtWorker_IsRoyalty.cs
+++ b/1.6/Source/VanillaSocialInteractionsExpanded/Thoughts/ThoughtWorker_IsRoyalty.cs
@@ -29,9 +29,9 @@ namespace VanillaSocialInteractionsExpanded
 
 		public bool IsRoyalty(Pawn pawn, Pawn other)
         {
-			var pawnTitle = pawn.royalty.MostSeniorTitle;
-			var otherTitle = other.royalty.MostSeniorTitle;
-			if (otherTitle != null)
+			var pawnTitle = pawn?.royalty?.MostSeniorTitle;
+			var otherTitle = other?.royalty?.MostSeniorTitle;
+			if (otherTitle is not null)
             {
 				if (pawnTitle is null || otherTitle.def.seniority > pawnTitle.def.seniority)
 				{


### PR DESCRIPTION
Addresses issue #3 reported by adding in a null check on the `royalty` and `MostSeniorTitle` fields.